### PR TITLE
Add find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name="smax",
     version="0.0.1",
+    packages=find_packages()
 )


### PR DESCRIPTION
This is needed when I install this within in a docker container for some reason. 

I don't know why, but I know it was broken and now is not so broken.