### PR TITLE
Update JaxMARL_Walkthrough.ipynb

### DIFF
--- a/jaxmarl/tutorials/JaxMARL_Walkthrough.ipynb
+++ b/jaxmarl/tutorials/JaxMARL_Walkthrough.ipynb
@@ -714,7 +714,7 @@
         "    observations, rewards, terminations, truncations, infos = env.step(actions)\n",
         "\n",
         "zoo_time = time.time() - start_time\n",
-        "zoo_sps = max_steps/zoo_time\n",
+        "zoo_sps = config[\"NUM_STEPS\"]/zoo_time\n",
         "\n",
         "\n",
         "print(f\"PettingZoo Total Time (s): {zoo_time}\")\n",


### PR DESCRIPTION
fix SPS counting for pettingzoo.
The numbers shown in the notebook do not match the blog. For the petting zoo, there was a mistake in counting sps.