### PR TITLE
Add imageio requirements.txt to make overcooked IPPO baseline work

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,3 +15,4 @@ hydra-core>=1.3.2
 omegaconf>=2.3.0
 safetensors>=0.3.3
 optax>=0.1.4
+imageio>=2.33.1


### PR DESCRIPTION
The `overcooked_visualize.py::animate` requires `imageio`.

Adding the current version ">=" to the `requirements.txt`

https://github.com/FLAIROx/JaxMARL/blob/main/jaxmarl/viz/overcooked_visualizer.py#L38