### PR TITLE
Fixing incomplete state update issue in the step function of STORM environemnt

### DIFF
--- a/jaxmarl/environments/storm/storm_2p.py
+++ b/jaxmarl/environments/storm/storm_2p.py
@@ -751,17 +751,19 @@ class InTheGrid_2p(MultiAgentEnv):
             inner_t = state_nxt.inner_t
             outer_t = state_nxt.outer_t
             reset_inner = inner_t == num_inner_steps
-            done = {}
-            done["__all__"] = reset_inner = inner_t == num_inner_steps
 
             # if inner episode is done, return start state for next game
-            # state_re = _reset_state(key)
-            # state_re = state_re.replace(outer_t=outer_t + 1)
-            # state = jax.tree_map(
-            #     lambda x, y: jax.lax.select(reset_inner, x, y),
-            #     state_re,
-            #     state_nxt,
-            # )
+            state_re = _reset_state(key)
+            state_re = state_re.replace(outer_t=outer_t + 1)
+            state = jax.tree_map(
+                lambda x, y: jax.lax.select(reset_inner, x, y),
+                state_re,
+                state_nxt,
+            )
+            outer_t = state.outer_t
+            reset_outer = outer_t == num_outer_steps
+            done = {}
+            done["__all__"] = reset_outer
 
             obs = _get_obs(state)
             blue_reward = jnp.where(reset_inner, 0, blue_reward)

--- a/jaxmarl/environments/storm/storm_env.py
+++ b/jaxmarl/environments/storm/storm_env.py
@@ -904,7 +904,7 @@ class InTheGrid(MultiAgentEnv):
 
             return (
                 obs,
-                state,
+                state_nxt,
                 rewards,
                 done,
                 {"discount": jnp.zeros((), dtype=jnp.int8)},

--- a/jaxmarl/environments/storm/storm_env.py
+++ b/jaxmarl/environments/storm/storm_env.py
@@ -886,25 +886,27 @@ class InTheGrid(MultiAgentEnv):
             # now calculate if done for inner or outer episode
             inner_t = state_nxt.inner_t
             outer_t = state_nxt.outer_t
-            done = {}
-            done["__all__"] = reset_inner = inner_t == num_inner_steps
-
+            reset_inner = inner_t == num_inner_steps
 
             # # # if inner episode is done, return start state for next game
-            # state_re = _reset_state(key)
-            # state_re = state_re.replace(outer_t=outer_t + 1)
-            # state = jax.tree_map(
-            #     lambda x, y: jax.lax.select(reset_inner, x, y),
-            #     state_re,
-            #     state_nxt,
-            # )
+            state_re = _reset_state(key)
+            state_re = state_re.replace(outer_t=outer_t + 1)
+            state = jax.tree_map(
+                lambda x, y: jax.lax.select(reset_inner, x, y),
+                state_re,
+                state_nxt,
+            )
+            outer_t = state.outer_t
+            reset_outer = outer_t == num_outer_steps
+            done = {}
+            done["__all__"] = reset_outer
 
             obs = _get_obs(state)
             rewards = jnp.where(reset_inner, 0, rewards)
 
             return (
                 obs,
-                state_nxt,
+                state,
                 rewards,
                 done,
                 {"discount": jnp.zeros((), dtype=jnp.int8)},

--- a/jaxmarl/tutorials/storm_2p_introduction.py
+++ b/jaxmarl/tutorials/storm_2p_introduction.py
@@ -8,7 +8,7 @@ from jaxmarl.environments.storm.storm_2p import Items
 
 action = 1
 render_agent_view = True
-num_outer_steps = 1
+num_outer_steps = 3
 num_inner_steps = 152
 
 rng = jax.random.PRNGKey(0)
@@ -58,6 +58,9 @@ for t in range(num_outer_steps * num_inner_steps):
         rng, old_state, (a1 * action, a2 * action)
     )
 
+    print('outer t', state.outer_t)
+    print('inner t', state.inner_t)
+    print('done', done)
     if (state.red_pos[:2] == state.blue_pos[:2]).all():
         import pdb
 

--- a/jaxmarl/tutorials/storm_introduction.py
+++ b/jaxmarl/tutorials/storm_introduction.py
@@ -8,7 +8,7 @@ from jaxmarl.environments.storm.storm_env import Items
 
 action=1
 render_agent_view = False
-num_outer_steps = 1
+num_outer_steps = 3
 # num_inner_steps = 68
 #num_agents=8
 num_agents=2
@@ -96,22 +96,9 @@ for t in range(num_outer_steps * num_inner_steps):
     obs, state, reward, done, info = env.step_env(
         rng, old_state, [a*action for a in actions]
     )
-    # print(state.agent_inventories, 'agent inventories')
-    # print(actions.shape, 'actions')
-    # print(state.agent_positions.shape, 'agent positions')
-    # print(state.agent_freezes.shape, 'agent freezes')
-    # if (state.grid == old_state.grid).all():
-    #     print(t, 'hello there')
-
-    # if (state.red_pos[:2] == state.blue_pos[:2]).all():
-    #     import pdb
-
-    #     # pdb.set_trace()
-    #     print("collision")
-    #     print(
-    #         f"timestep: {t}, A1: {int_action[a1.item()]} A2:{int_action[a2.item()]}"
-    #     )
-    #     print(state.red_pos, state.blue_pos)
+    print('outer t', state.outer_t)
+    print('inner t', state.inner_t)
+    print('done', done)
 
     img = env.render(state)
     Image.fromarray(img).save(f"state_pics/state_{t+1}.png")


### PR DESCRIPTION
The `_step()` was returning a state where some fields were not updated, leading to inaccuracies in the calculation of `done`. Specifically, while `agent_freezes`, `agent_positions`, and other fields were updated, `inner_t` remained unchanged in the returned `state`.

To fix this, I've replaced `state_nxt` that all fields are updated, ensuring accurate `done` calculations.

Please review, and feel free to provide any additional feedback or suggestions for further refinement.