### PR TITLE
Fix action-direction mismatch

### DIFF
--- a/jaxmarl/environments/overcooked/common.py
+++ b/jaxmarl/environments/overcooked/common.py
@@ -66,10 +66,6 @@ OBJECT_INDEX_TO_VEC = jnp.array([
 # Map of agent direction indices to vectors
 DIR_TO_VEC = jnp.array([
 	# Pointing right (positive X)
-	# (1, 0), # right
-	# (0, 1), # down
-	# (-1, 0), # left
-	# (0, -1), # up
 	(0, -1), # NORTH
 	(0, 1), # SOUTH
 	(1, 0), # EAST

--- a/jaxmarl/environments/overcooked/overcooked.py
+++ b/jaxmarl/environments/overcooked/overcooked.py
@@ -23,10 +23,10 @@ from jaxmarl.environments.overcooked.layouts import overcooked_layouts as layout
 
 class Actions(IntEnum):
     # Turn left, turn right, move forward
-    right = 0
+    up = 0
     down = 1
-    left = 2
-    up = 3
+    right = 2
+    left = 3
     stay = 4
     interact = 5
     done = 6
@@ -78,10 +78,10 @@ class Overcooked(MultiAgentEnv):
         self.agents = ["agent_0", "agent_1"]
 
         self.action_set = jnp.array([
-            Actions.right,
-            Actions.down,
-            Actions.left,
             Actions.up,
+            Actions.down,
+            Actions.right,
+            Actions.left,
             Actions.stay,
             Actions.interact,
         ])

--- a/jaxmarl/viz/overcooked_visualizer.py
+++ b/jaxmarl/viz/overcooked_visualizer.py
@@ -139,7 +139,10 @@ class OvercookedVisualizer:
 				(0.87, 0.50),
 				(0.12, 0.81),
 			)
-			tri_fn = rendering.rotate_fn(tri_fn, cx=0.5, cy=0.5, theta=0.5*math.pi*agent_dir_idx)
+			# A bit hacky, but needed so that actions order matches the one of Overcooked-AI
+			direction_reording = [3,1,0,2]
+			direction = direction_reording[agent_dir_idx]
+			tri_fn = rendering.rotate_fn(tri_fn, cx=0.5, cy=0.5, theta=0.5*math.pi*direction)
 			rendering.fill_coords(img, tri_fn, COLORS[color])
 		elif obj_type == OBJECT_TO_INDEX['empty']:
 			rendering.fill_coords(img, rendering.point_in_rect(0, 1, 0, 1), COLORS[color])


### PR DESCRIPTION
Fixes mismatch between actions and where the agent would end up facing.

Now an agent taking e.g. the "North" action will be facing North after that action. 

Expect no change or slight improvement in performance after this change. 