### PR TITLE
Fix hint masking dimensions and restructure deck insertion.

### DIFF
--- a/jaxmarl/environments/hanabi/hanabi.py
+++ b/jaxmarl/environments/hanabi/hanabi.py
@@ -147,6 +147,13 @@ class HanabiEnv(HanabiGame):
         return obs, state
 
     @partial(jax.jit, static_argnums=[0])
+    def reset_from_deck_of_pairs(self, key: chex.PRNGKey, deck: chex.Array) -> Tuple[Dict, State]:
+        """Inject a deck from (color, rank) pairs."""
+        state = self.reset_game_from_deck_of_pairs(key, deck)
+        obs = self.get_obs(state, state, action=20)
+        return obs, state
+
+    @partial(jax.jit, static_argnums=[0])
     def step_env(
         self,
         key: chex.PRNGKey,


### PR DESCRIPTION
This will add the following two changes:

1. Fixes dimension for masking when giving out hints. There was an issue when games were played with 3+ players since broadcasting wasn't possible in that case.
2. Adds a utility function for inserting deck from `(color, rank)` pairs. Previously, we needed to one hot encode before inserting a deck, now we have another method of inserting the deck. This also led to small refactoring where we extract the one hot encoding into a protected func.