### PR TITLE
Update smax_env.py

### DIFF
--- a/jaxmarl/environments/smax/smax_env.py
+++ b/jaxmarl/environments/smax/smax_env.py
@@ -262,12 +262,12 @@ class SMAX(MultiAgentEnv):
     def reset(self, key: chex.PRNGKey) -> Tuple[Dict[str, chex.Array], State]:
         """Environment-specific reset."""
         key, team_0_key, team_1_key = jax.random.split(key, num=3)
-        team_0_start = jnp.stack([jnp.array([8.0, 16.0])] * self.num_allies)
+        team_0_start = jnp.stack([jnp.array([self.map_width / 4, self.map_height / 2])] * self.num_allies)
         team_0_start_noise = jax.random.uniform(
             team_0_key, shape=(self.num_allies, 2), minval=-2, maxval=2
         )
         team_0_start = team_0_start + team_0_start_noise
-        team_1_start = jnp.stack([jnp.array([24.0, 16.0])] * self.num_enemies)
+        team_1_start = jnp.stack([jnp.array([self.map_width / 4 * 3, self.map_height / 2])] * self.num_enemies)
         team_1_start_noise = jax.random.uniform(
             team_1_key, shape=(self.num_enemies, 2), minval=-2, maxval=2
         )


### PR DESCRIPTION
Start positions are currently hard-coded to assume that the map_width and height is 32. If the map width is set to 128, the units will this start in the top-left corner.

Make team_0 and team_1 start y coordinates halfway up the map_height (instead of hard-coded 16). The x coordinate will be a fourth of the map_width, and three fourths of the map_width, respectively.