### PR TITLE
Fix bugs in baselines after merging PR #138

### DIFF
--- a/baselines/IPPO/ippo_ff_hanabi.py
+++ b/baselines/IPPO/ippo_ff_hanabi.py
@@ -95,7 +95,7 @@ def make_train(config):
         rng, _rng = jax.random.split(rng)
         init_x = (
             jnp.zeros(
-                (1, config["NUM_ENVS"], env.observation_space(env.agents[0]).n)
+                (1, config["NUM_ENVS"], env.observation_space(env.agents[0]).shape)
             ),
             jnp.zeros((1, config["NUM_ENVS"])),
             jnp.zeros((1, config["NUM_ENVS"], env.action_space(env.agents[0]).n))

--- a/baselines/IPPO/ippo_rnn_hanabi.py
+++ b/baselines/IPPO/ippo_rnn_hanabi.py
@@ -138,7 +138,7 @@ def make_train(config):
         rng, _rng = jax.random.split(rng)
         init_x = (
             jnp.zeros(
-                (1, config["NUM_ENVS"], env.observation_space(env.agents[0]).n)
+                (1, config["NUM_ENVS"], env.observation_space(env.agents[0]).shape)
             ),
             jnp.zeros((1, config["NUM_ENVS"])),
             jnp.zeros((1, config["NUM_ENVS"], env.action_space(env.agents[0]).n))

--- a/baselines/MAPPO/mappo_ff_hanabi.py
+++ b/baselines/MAPPO/mappo_ff_hanabi.py
@@ -171,7 +171,7 @@ def make_train(config):
         critic_network = CriticFF(config)
         rng, _rng_actor, _rng_critic = jax.random.split(rng, 3)
         ac_init_x = (
-            jnp.zeros((env.observation_space(env.agents[0]).n,)),
+            jnp.zeros((env.observation_space(env.agents[0]).shape,)),
             jnp.zeros((env.action_space(env.agents[0]).n,)),
         )
         actor_network_params = actor_network.init(_rng_actor, ac_init_x)

--- a/baselines/MAPPO/mappo_rnn_hanabi.py
+++ b/baselines/MAPPO/mappo_rnn_hanabi.py
@@ -199,7 +199,7 @@ def make_train(config):
         critic_network = CriticRNN(config=config)
         rng, _rng_actor, _rng_critic = jax.random.split(rng, 3)
         ac_init_x = (
-            jnp.zeros((1, config["NUM_ENVS"], env.observation_space(env.agents[0]).n)),
+            jnp.zeros((1, config["NUM_ENVS"], env.observation_space(env.agents[0]).shape)),
             jnp.zeros((1, config["NUM_ENVS"])),
             jnp.zeros((1, config["NUM_ENVS"], env.action_space(env.agents[0]).n)),
         )


### PR DESCRIPTION
Changed observation space initialization in Hanabi environment implementations

Key changes:
Updated observation space initialization from `.n` to `.shape` in:
  - MAPPO feedforward and recurrent implementations
  - IPPO feedforward and recurrent implementations

This change aligns with the transition of Hanabi's observation space from Discrete to Box type (referencing PR #138 ). The modifications ensure proper initialization of networks when receiving Box-shaped observations.