### PR TITLE
Fix num_layers calculation in _get_obs_shape_single of OvercookedV2

### DIFF
--- a/jaxmarl/environments/overcooked_v2/overcooked.py
+++ b/jaxmarl/environments/overcooked_v2/overcooked.py
@@ -511,7 +511,7 @@ class OvercookedV2(MultiAgentEnv):
                 case ObservationType.DEFAULT:
                     num_ingredients = self.layout.num_ingredients
                     #17(Invariable objects[5 position and directions for each agents, wall, goal, pot, plate pile, recipe indicator, button, pot timer] + 4*(num_ingredients+2) objects[Inventory for each agents, recipe, grid] + N(ingredient pile))
-                    num_layers = 17 + N + 4 * (num_ingredients + 2)
+                    num_layers = 17 + num_ingredients + 4 * (num_ingredients + 2)
 
                     if self.indicate_successful_delivery:
                         num_layers += 1

--- a/jaxmarl/environments/overcooked_v2/overcooked.py
+++ b/jaxmarl/environments/overcooked_v2/overcooked.py
@@ -510,7 +510,8 @@ class OvercookedV2(MultiAgentEnv):
             match obs_type:
                 case ObservationType.DEFAULT:
                     num_ingredients = self.layout.num_ingredients
-                    num_layers = 18 + 4 * (num_ingredients + 2)
+                    #17(Invariable objects[5 position and directions for each agents, wall, goal, pot, plate pile, recipe indicator, button, pot timer] + 4*(num_ingredients+2) objects[Inventory for each agents, recipe, grid] + N(ingredient pile))
+                    num_layers = 17 + N + 4 * (num_ingredients + 2)
 
                     if self.indicate_successful_delivery:
                         num_layers += 1


### PR DESCRIPTION
The channel computing logic from original code is
num_layers = 18 + 4 * (num_ingredients + 2)
But, it should be
num_layers = 17 + N + 4 * (num_ingredients + 2)
since 17(Invariable objects[5 position and directions for each agents, wall, goal, pot, plate pile, recipe indicator, button, pot timer] + 4*(num_ingredients+2) objects[Inventory for each agents, recipe, grid] + N(ingredient pile)).