### PR TITLE
[Bug Fix] RNN done alignment in Overcooked V2 IPPO

### DIFF
--- a/baselines/IPPO/ippo_rnn_overcooked_v2.py
+++ b/baselines/IPPO/ippo_rnn_overcooked_v2.py
@@ -200,6 +200,7 @@ class ActorCritic(nn.Module):
 
 
 class Transition(NamedTuple):
+    global_done: jnp.ndarray
     done: jnp.ndarray
     action: jnp.ndarray
     value: jnp.ndarray
@@ -373,6 +374,7 @@ def make_train(config):
                 done_batch = batchify(done, env.agents, config["NUM_ACTORS"]).squeeze()
                 transition = Transition(
                     jnp.tile(done["__all__"], env.num_agents),
+                    last_done,
                     action.squeeze(),
                     value.squeeze(),
                     batchify(reward, env.agents, config["NUM_ACTORS"]).squeeze(),
@@ -414,7 +416,7 @@ def make_train(config):
                 def _get_advantages(gae_and_next_value, transition):
                     gae, next_value = gae_and_next_value
                     done, value, reward = (
-                        transition.done,
+                        transition.global_done,
                         transition.value,
                         transition.reward,
                     )


### PR DESCRIPTION
During rollout, `ippo_rnn_overcooked_v2.py` applies the recurrent policy with pre-step `last_done`, which is the correct reset signal for `ScannedRNN` because the hidden state is reset before processing the current
  observation. However, during PPO loss recomputation, the stored `traj_batch.done` was previously the post-step terminal flag. This meant the RNN replay reset on terminal observations rather than on the first observation
  after an episode ended.

  This change mirrors the convention already used by the other recurrent IPPO baselines:

  - `global_done`: post-step done, used for GAE bootstrapping.
  - `done`: pre-step `last_done`, used for RNN replay.

  ## Changes

  - Adds `global_done` to the Overcooked V2 IPPO transition tuple.
  - Stores post-step environment termination in `global_done`.
  - Stores pre-step `last_done` in `done`.
  - Uses `global_done` for GAE computation.
  - Leaves RNN replay using `traj_batch.done`, now correctly reset-aligned.
